### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ $api->setAppLimits([
 ], $pool);
 
 // When using Laravel
-$store = app(\Illuminate\Cache\Repository::class)->getStore();
+$store = \Illuminate\Support\Facades\Cache::store()->getStore();
+// .... or by using the Cache Facade
+$store = \Cache::store()->getStore();
+
 $pool = new \Cache\Adapter\Illuminate\IlluminateCachePool($store);
 
 $api->setLimits([


### PR DESCRIPTION
No need to use app() with the Repository class. You can use the Cache Facade and access the Store from there.