### PR TITLE
Add additional match list method api calls.

### DIFF
--- a/src/LeagueWrap/Api/Match.php
+++ b/src/LeagueWrap/Api/Match.php
@@ -25,4 +25,14 @@ class Match extends BaseApi
     {
         return $this->byIds($ids);
     }
+    
+    public function getRecentMatchListByAccountId(array $accountIds)
+    {
+        return $this->getAsync($this->createEndpointsFromIds($accountIds, MatchRecentMatchlistByAccountId::class));
+    }
+
+    public function getMatchListByAccountId(array $accountIds)
+    {
+        return $this->getAsync($this->createEndpointsFromIds($accountIds, MatchMatchlistByAccountId::class));
+    }
 }


### PR DESCRIPTION
Added two methods that I didn't see implemented anywhere to get a list of matches by account Id.

I noticed you had MatchRecentMatchlistByAccountId and MatchMatchlistByAccountId classes created, but hadn't implemented them anywhere.

Appreciate the repo.